### PR TITLE
Added `e.stopPropogation` for React 17 upgrade

### DIFF
--- a/src/EventEndingRow.js
+++ b/src/EventEndingRow.js
@@ -104,6 +104,7 @@ class EventEndingRow extends React.Component {
   showMore(slot, e) {
     e.preventDefault()
     this.props.onShowMore(slot)
+    e.stopPropagation()
   }
 }
 


### PR DESCRIPTION
Fixes "show more" bug due to event architecture changing in React 17.
